### PR TITLE
minseglen bug

### DIFF
--- a/R/multiple_nonparametric.R
+++ b/R/multiple_nonparametric.R
@@ -14,6 +14,9 @@ multiple.nonparametric.ed=function(data,mul.method="PELT",penalty="MBIC",pen.val
   else{
     n=ncol(data)
   }
+  if(minseglen>floor(n/2)){
+	  stop("Minimum segment length is too long to allow any changepoints")
+  }
 
   pen.value = penalty_decision(penalty, pen.value, n, diffparam, method=mul.method)
 

--- a/R/range_of_penalties.R
+++ b/R/range_of_penalties.R
@@ -5,6 +5,9 @@ range_of_penalties <- function(sumstat,cost = "empirical_distribution",PELT = T,
   NCALC=0
   pen_interval <- c(min_pen,max_pen)
   n = dim(sumstat)[2]-1
+  if(minseglen>floor(n/2)){
+	  stop("Minimum segment length is too long to allow any changepoints")
+  }
 
   test_penalties <- NULL
   numberofchangepoints <- NULL


### PR DESCRIPTION
Found bug where R would abort if the minimum segment length was greater than the length of the data. Have added an error message to catch this - an error is flagged if the minseglen is greater than half the length of the data.